### PR TITLE
Resolve #43 - Logging is no longer mandatory

### DIFF
--- a/CSF.Extensions.WebDriver.Tests/Factories/WebDriverFactoryIntegrationTests.cs
+++ b/CSF.Extensions.WebDriver.Tests/Factories/WebDriverFactoryIntegrationTests.cs
@@ -49,7 +49,7 @@ public class WebDriverFactoryIntegrationTests
 
     public class FakeWebDriverFactory : ICreatesWebDriverFromOptions
     {
-        public WebDriverAndOptions GetWebDriver(WebDriverCreationOptions options, Action<DriverOptions> supplementaryConfiguration = null)
+        public WebDriverAndOptions GetWebDriver(WebDriverCreationOptions options, Action<DriverOptions>? supplementaryConfiguration = null)
         {
             return new(Mock.Of<IWebDriver>(), Mock.Of<DriverOptions>());
         }

--- a/CSF.Extensions.WebDriver.Tests/ServiceCollectionExtensionsTests.cs
+++ b/CSF.Extensions.WebDriver.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,18 @@
+using CSF.Extensions.WebDriver.Factories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CSF.Extensions.WebDriver;
+
+[TestFixture,Parallelizable]
+public class ServiceCollectionExtensionsTests
+{
+    [Test,AutoMoqData]
+    public void AddWebDriverFactoryWithoutOptionsPatternShouldNotCrashWhenResolvingBecauseOfMissingLogging()
+    {
+        var services = new ServiceCollection();
+        services.AddWebDriverFactoryWithoutOptionsPattern();
+        var serviceProvider = services.BuildServiceProvider();
+
+        Assert.That(serviceProvider.GetRequiredService<ICreatesWebDriverFromOptions>, Throws.Nothing);
+    }
+}

--- a/CSF.Extensions.WebDriver/ServiceCollectionExtensions.cs
+++ b/CSF.Extensions.WebDriver/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Castle.DynamicProxy;
 using CSF.Extensions.WebDriver.Factories;
 using CSF.Extensions.WebDriver.Identification;
@@ -6,6 +7,8 @@ using CSF.Extensions.WebDriver.Proxies;
 using CSF.Extensions.WebDriver.Quirks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace CSF.Extensions.WebDriver
@@ -164,6 +167,8 @@ namespace CSF.Extensions.WebDriver
             services.AddTransient<IdentificationAugmenter>();
             services.AddTransient<UnproxyingAugmenter>();
 
+            AddLoggingIfNotAlreadyAdded(services);
+
             return services;
         }
 
@@ -240,6 +245,17 @@ namespace CSF.Extensions.WebDriver
             {
                 return ActivatorUtilities.CreateInstance<WebDriverCreationConfigureOptions>(services, configSection, configureOptions);
             };
+        }
+
+        static IServiceCollection AddLoggingIfNotAlreadyAdded(IServiceCollection services)
+        {
+            if(services.Any(s => s.ServiceType == typeof(ILoggerFactory)))
+                return services;
+
+            services.AddTransient<ILoggerFactory, NullLoggerFactory>();
+            services.AddTransient(typeof(ILogger<>), typeof(NullLogger<>));
+
+            return services;
         }
     }
 }


### PR DESCRIPTION
Resolves a crash issue whereby resolution of services
would crash if no logger had been added.